### PR TITLE
fix(protocol): optimize idLength calculation in Packet class

### DIFF
--- a/modules/protocol/base/src/main/java/candle/protocol/Packet.java
+++ b/modules/protocol/base/src/main/java/candle/protocol/Packet.java
@@ -21,7 +21,7 @@ public class Packet {
     this.state = state;
     this.length = readVarInt(in);
     this.id = readVarInt(in);
-    int idLength = (Integer.toBinaryString(id).length() + 7) / 8;
+    int idLength = (38 - Integer.numberOfLeadingZeros(this.id | 1)) / 7;
     data = in.readNBytes(this.length - idLength);
   }
 


### PR DESCRIPTION
Refactor the idLength calculation to improve performance and  readability. The new method uses Integer.numberOfLeadingZeros  for a more efficient computation, ensuring accurate results  while reducing complexity.